### PR TITLE
Offer reset config and fix darwin/arm64 build

### DIFF
--- a/core/auxiliary.go
+++ b/core/auxiliary.go
@@ -1,6 +1,9 @@
 package core
 
 import (
+	"bufio"
+	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -38,4 +41,22 @@ func convertHexToRgb(hex string) (r, g, b uint8, err error) {
 	g = uint8((rgb & 0x00ff00) >> 8)
 	b = uint8(rgb & 0x0000ff)
 	return r, g, b, nil
+}
+
+// AskUser asks the user a yes/no question and returns true if the user answers
+// yes.
+func AskUser(question string) (bool, error) {
+	// Ask the user
+	fmt.Printf("%s (y/N): ", question)
+	// Read user input
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	// Normalize input
+	input = strings.ToLower(input)
+	input = strings.TrimSpace(input)
+	// Check input
+	return input == "y" || input == "yes", nil
 }

--- a/main.go
+++ b/main.go
@@ -10,9 +10,25 @@ import (
 func main() {
 	// Get configuration
 	config, err := core.Load()
+	// If there was an error loading the config, offer the user the option to
+	// reset it (or simply exit).
 	if err != nil {
-		fmt.Println("error handling configuration:", err)
-		os.Exit(1)
+		fmt.Println("error loading configuration:", err)
+		// Ask the user if they want to reset the config
+		if ok, in_err := core.AskUser("Reset configuration?"); in_err != nil {
+			fmt.Println("error asking user:", in_err)
+			os.Exit(1)
+		} else if ok {
+			// Reset config
+			config, in_err = core.SaveDefault()
+			if in_err != nil {
+				fmt.Println("error resetting configuration:", in_err)
+				os.Exit(1)
+			}
+		} else {
+			// Exit
+			os.Exit(0)
+		}
 	}
 	// Parse flags
 	config, t, changed, err := core.ParseFlags(config, Version)

--- a/material/scripts/buildall.sh
+++ b/material/scripts/buildall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Specify platforms to build for
-platforms=("linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64", "windows/amd64")
+platforms=("linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64")
 
 # Clean build directory
 builddir="build"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "v0.1.0"
+const Version = "v0.1.1"


### PR DESCRIPTION
# Description

The behavior of simply resetting the config, if any error occurs reading it is too aggressive. This PR shows the error and offers the user the option to reset it instead. Furthermore, this PR fixes a cross build problem that caused no Mac M1 binary to be available in the release.

## Changes

- Offer user to reset config instead of just doing it
- Fixes Mac M1 a.k.a. darwin/arm64 build

Resolves #4 