### PR TITLE
Add support for JSONC config file

### DIFF
--- a/core/configuration.go
+++ b/core/configuration.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/adrg/xdg"
+	"github.com/tidwall/jsonc"
 )
 
 // ConfigVersion is the current version of the configuration file.
@@ -161,7 +162,7 @@ func Load() (Config, error) {
 		return config, errors.New("Error reading config file: " + err.Error())
 	}
 	// Unmarshal
-	err = json.Unmarshal(data, &config)
+	err = json.Unmarshal(jsonc.ToJSON(data), &config)
 	if err != nil {
 		return config, errors.New("Error unmarshaling config file: " + err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/adrg/xdg v0.4.0
 	github.com/gdamore/tcell/v2 v2.4.0
+	github.com/tidwall/jsonc v0.3.2
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf
 )
 

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
+github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
By running the config file through this JSONC converter (https://github.com/tidwall/jsonc), comments and trailing commas won't be picked up as errors and can remain in the file without effecting any of the syntax.

With this change the example configuration file in the README can be pasted in config.json and used as-is, which makes it a bit easier for new users to customize their setup.

P.S.
This is first time I've actually worked with Go, so apologies if I've missed something.