### PR TITLE
If color enabled, use solid block for night

### DIFF
--- a/core/format.go
+++ b/core/format.go
@@ -174,7 +174,12 @@ func GetHourSymbol(sty Style, hour int) string {
 	// Get symbol depending on symbol mode
 	switch sty.Symbols {
 	case SymbolModeRectangles:
-		return RectangleSymbols[getDaySegment(sty.DaySegmentation, hour)]
+		// Return solid block if color mode is enabled
+		if (sty.Colorize && (RectangleSymbols[getDaySegment(sty.DaySegmentation, hour)] == " ")){
+			return "█"
+		} else {
+			return RectangleSymbols[getDaySegment(sty.DaySegmentation, hour)]
+		}
 	case SymbolModeSunMoon:
 		return SunMoonSymbols[getDaySegment(sty.DaySegmentation, hour)]
 	case SymbolModeMono:


### PR DESCRIPTION
Basically, this checks to see if colors are enabled, and if so, uses the same solid block character for day and night in "rectangles" mode. I can see why you would want to use blank character for night if color mode is off, but since we are able to set different colors for day and night, there's no conflict when using the same character.

The following shows the difference when switching "colorize" from false to true:

![nightblock](https://user-images.githubusercontent.com/1843361/169674258-f03e9797-c86e-4207-bb11-a2ba6ce31d20.jpg)

For me personally, the ability to set a night color makes more visual sense than just leaving the space blank.
