### PR TITLE
Custom symbol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,17 @@ The configuration is stored in `$XDG_CONFIG_HOME/gotz/config.json` (usually `~/.
     ],
     // Configures the style of the plot
     "style": {
-        // Select symbols to use for the time blocks (one of 'mono', 'rectangles' or 'sun-moon')
+        // Select symbols to use for the time blocks
+        // (one of 'mono', 'rectangles', 'blocks', 'sun-moon' or 'custom')
         "symbols": "mono",
+        // Define custom symbols (used if 'symbols' is 'custom')
+        // Each symbol is used from its start time (hour in day as int) until the next symbol
+        "custom_symbols": [
+            { "Start": 6, "Symbol": "▓" },
+            { "Start": 8, "Symbol": "█" },
+            { "Start": 18, "Symbol": "▓" },
+            { "Start": 22, "Symbol": "░" }
+        ],
         // Indicates whether to use coloring at all
         "colorize": true,
         // Configures how the day is segmented

--- a/core/args.go
+++ b/core/args.go
@@ -94,8 +94,9 @@ func ParseFlags(startConfig Config, appVersion string) (Config, time.Time, bool,
 	if symbols != "" {
 		changed = true
 		startConfig.Style.Symbols = symbols
-		if !checkSymbolMode(startConfig.Style.Symbols) {
-			return startConfig, time.Time{}, false, fmt.Errorf("invalid symbol mode: %s", symbols)
+		symbolError := checkSymbolMode(startConfig.Style.Symbols)
+		if symbolError != nil {
+			return startConfig, time.Time{}, changed, symbolError
 		}
 	}
 	if tics != "" {

--- a/tests/plot_test.go
+++ b/tests/plot_test.go
@@ -41,26 +41,9 @@ func TestTableStatic(t *testing.T) {
 	loc, _ := time.LoadLocation("Europe/Berlin")
 	testTime := time.Date(1985, 8, 24, 16, 0, 0, 0, loc)
 
-	// Setup plotter (collect output in stringbuilder for comparison)
-	sb := strings.Builder{}
-	plotter := core.Plotter{
-		Now:           true,
-		TerminalWidth: 72,
-		PlotLine: func(t core.ContextType, line ...interface{}) {
-			_ = t
-			sb.WriteString(fmt.Sprint(line...) + "\n")
-		},
-		PlotString: func(t core.ContextType, msg string) {
-			_ = t
-			sb.WriteString(msg)
-		},
-	}
-
 	// Run all tests
 	for _, configFile := range testConfigurations {
 		t.Run(strings.Replace(configFile, ".json", "", -1), func(t *testing.T) {
-			// Reset stringbuilder
-			sb.Reset()
 			// Read configuration file
 			var config core.Config
 			data, err := ioutil.ReadFile(configFile)
@@ -77,6 +60,21 @@ func TestTableStatic(t *testing.T) {
 			expected, err := readExpectation(goldenFile)
 			if err != nil && !*update {
 				t.Fatal(err)
+			}
+			// Setup plotter (collect output in stringbuilder for comparison)
+			sb := strings.Builder{}
+			plotter := core.Plotter{
+				Now:           true,
+				TerminalWidth: 72,
+				PlotLine: func(t core.ContextType, line ...interface{}) {
+					_ = t
+					sb.WriteString(fmt.Sprint(line...) + "\n")
+				},
+				PlotString: func(t core.ContextType, msg string) {
+					_ = t
+					sb.WriteString(msg)
+				},
+				Symbols: core.GetSymbols(config.Style),
 			}
 			// Create plot
 			err = core.PlotTime(plotter, config, testTime)

--- a/tests/testdata/static_custom.golden
+++ b/tests/testdata/static_custom.golden
@@ -1,0 +1,11 @@
+                                now v 16:00
+Local   : Sat 24 Aug 1985 14:00     |
+____________OOOOOOXXXXXXXXXXXXXXXXXX|XXXXXXXXXXXOOOOOOOOOOOO____________
+New York: Sat 24 Aug 1985 10:00     |
+________________________OOOOOOXXXXXX|XXXXXXXXXXXXXXXXXXXXXXXOOOOOOOOOOOO
+Berlin  : Sat 24 Aug 1985 16:00     |
+______OOOOOOXXXXXXXXXXXXXXXXXXXXXXXX|XXXXXOOOOOOOOOOOO__________________
+Shanghai: Sat 24 Aug 1985 22:00     |
+XXXXXXXXXXXXXXXXXXXXXXXXOOOOOOOOOOOO|_______________________OOOOOOXXXXXX
+Sydney  : Sun 25 Aug 1985 00:00     |
+XXXXXXXXXXXXXXXXXXOOOOOOOOOOOO______|_________________OOOOOOXXXXXXXXXXXX

--- a/tests/testdata/static_custom.json
+++ b/tests/testdata/static_custom.json
@@ -1,0 +1,66 @@
+{
+  "config_version": "1.0",
+  "timezones": [
+    {
+      "Name": "New York",
+      "TZ": "America/New_York"
+    },
+    {
+      "Name": "Berlin",
+      "TZ": "Europe/Berlin"
+    },
+    {
+      "Name": "Shanghai",
+      "TZ": "Asia/Shanghai"
+    },
+    {
+      "Name": "Sydney",
+      "TZ": "Australia/Sydney"
+    }
+  ],
+  "style": {
+    "symbols": "custom",
+    "custom_symbols": [
+      {
+        "Start": 6,
+        "Symbol": "O"
+      },
+      {
+        "Start": 8,
+        "Symbol": "X"
+      },
+      {
+        "Start": 18,
+        "Symbol": "O"
+      },
+      {
+        "Start": 22,
+        "Symbol": "_"
+      }
+    ],
+    "colorize": true,
+    "day_segments": {
+      "morning": 6,
+      "day": 8,
+      "evening": 18,
+      "night": 22
+    },
+    "coloring": {
+      "StaticColorMorning": "red",
+      "StaticColorDay": "yellow",
+      "StaticColorEvening": "red",
+      "StaticColorNight": "blue",
+      "StaticColorForeground": "",
+      "DynamicColorMorning": "red",
+      "DynamicColorDay": "yellow",
+      "DynamicColorEvening": "red",
+      "DynamicColorNight": "blue",
+      "DynamicColorForeground": "",
+      "DynamicColorBackground": ""
+    }
+  },
+  "tics": false,
+  "stretch": true,
+  "hours12": false,
+  "live": false
+}


### PR DESCRIPTION
# Description

Adds support for custom symbols and a plain all blocks symbol mode.

## Changes

- Adds support for user-defined custom symbols
- Adds an all `blocks` symbol mode
- Fixes the color of the current time marker (same color for whole marker)