### PR TITLE
Fixes TZ data for windows binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ builds:
       - "386"
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+    flags: -tags=timetzdata
 checksum:
   name_template: "checksums.txt"
 changelog:


### PR DESCRIPTION
# Description

Fixes the regression of missing TZ data for releases relying on it (Windows). This PR re-adds the build flag that went missing when migrating to goreleaser.

## Changes

- Include TZ data (`timetzdata`) tag for build.