### PR TITLE
Adds version tag to goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - env:
       - CGO_ENABLED=0

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gotz
 Show arbitrary time:
 
 ```bash
-gotz 21
+gotz 15
 ```
 
 ![preview](material/screenshot/gotz-15-1.png)


### PR DESCRIPTION
# Description

Adds the version tag to the goreleaser config to avoid the warning or unforeseen issues with the config.

## Changes

* Adds version tag to goreleaser config.
* Fixes example in README.